### PR TITLE
fix CIL double type name

### DIFF
--- a/src/Language/Cil/Parser.hs
+++ b/src/Language/Cil/Parser.hs
@@ -72,7 +72,7 @@ pPrimitiveType =  Void <$  pKey "void"
               <|> Int32 <$ pKey "int32"
               <|> Int64 <$ pKey "int64"
               <|> Float32 <$ pKey "float32"
-              <|> Double64 <$ pKey "double64"
+              <|> Double64 <$ pKey "float64"
               <|> String <$ pKey "string"
               <|> Object <$ pKey "object"
 

--- a/src/Language/Cil/Pretty.hs
+++ b/src/Language/Cil/Pretty.hs
@@ -345,7 +345,7 @@ instance Pretty PrimitiveType where
   pr Int32               = ("int32" ++)
   pr Int64               = ("int64" ++)
   pr Float32             = ("float32" ++)
-  pr Double64            = ("double64" ++)
+  pr Double64            = ("float64" ++)
   pr IntPtr              = ("native int" ++)
   pr String              = ("string" ++)
   pr Object              = ("object" ++)


### PR DESCRIPTION
The correct name is `float64`