### PR TITLE
Introduce ldftn_instance

### DIFF
--- a/src/Language/Cil/Build.hs
+++ b/src/Language/Cil/Build.hs
@@ -63,6 +63,7 @@ module Language.Cil.Build (
   , ldfld
   , ldflda
   , ldftn
+  , ldftn_instance
   , ldind_i
   , ldind_i1
   , ldind_i2
@@ -339,8 +340,14 @@ ldfld p a t f = OpCode $ Ldfld p a t f
 ldflda :: PrimitiveType -> AssemblyName -> TypeName -> FieldName -> MethodDecl
 ldflda p a t f = OpCode $ Ldflda p a t f
 
+ldftn_ :: [CallConv] -> PrimitiveType -> AssemblyName -> TypeName -> MethodName -> [PrimitiveType] -> MethodDecl
+ldftn_ cc p a t m ps = OpCode $ Ldftn cc p a t m ps
+
 ldftn :: PrimitiveType -> AssemblyName -> TypeName -> MethodName -> [PrimitiveType] -> MethodDecl
-ldftn p a t m ps = OpCode $ Ldftn p a t m ps
+ldftn = ldftn_ []
+
+ldftn_instance :: PrimitiveType -> AssemblyName -> TypeName -> MethodName -> [PrimitiveType] -> MethodDecl
+ldftn_instance = ldftn_ [CcInstance]
 
 ldind_i :: MethodDecl
 ldind_i = OpCode $ Ldind_i

--- a/src/Language/Cil/Pretty.hs
+++ b/src/Language/Cil/Pretty.hs
@@ -223,7 +223,7 @@ instance Pretty OpCode where
   pr (Ldelem_ref)          = ("ldelem.ref " ++)
   pr (Ldfld t a c f)       = ("ldfld " ++) . pr t . sp . prFld a c f
   pr (Ldflda t a c f)      = ("ldflda " ++) . pr t . sp . prFld a c f
-  pr (Ldftn t a c m ps)    = ("ldftn " ++) . pr t . sp . prCall a c m ps
+  pr (Ldftn cc t a c m ps) = ("ldftn " ++) . prList cc . pr t . sp . prCall a c m ps
   pr (Ldind_i)             = ("ldind.i " ++)
   pr (Ldind_i1)            = ("ldind.i1 " ++)
   pr (Ldind_i2)            = ("ldind.i2 " ++)

--- a/src/Language/Cil/Syntax.hs
+++ b/src/Language/Cil/Syntax.hs
@@ -293,7 +293,8 @@ data OpCode
       , fieldName    :: FieldName      -- ^ Name of the field.
       } -- ^ Pops object reference, find address of specified field on the object, pushes address to the stack.
   | Ldftn 
-      { returnType   :: PrimitiveType    -- ^ Return type of the method.
+      { callConv     :: [CallConv]       -- ^ Method is associated with class or instance.
+      , returnType   :: PrimitiveType    -- ^ Return type of the method.
       , assemblyName :: AssemblyName     -- ^ Name of the assembly where the method resides.
       , typeName     :: TypeName         -- ^ Name of the type of which the method is a member.
       , methodName   :: MethodName       -- ^ Name of the method.


### PR DESCRIPTION
In the interest of backwards compatibility I've preserved the semantics of `ldftn` and introduced a new function for instance method references.